### PR TITLE
feat: implement belt-kwp key wrap mode (STB 34.101.31)

### DIFF
--- a/BelTCrypto.Core/BelTKwp.cs
+++ b/BelTCrypto.Core/BelTKwp.cs
@@ -1,0 +1,80 @@
+﻿using BelTCrypto.Core.Interfaces;
+using System.Security.Cryptography;
+
+namespace BelTCrypto.Core;
+
+internal class BelTKwp : IBelTKwp
+{
+    private readonly IBelTWideBlock _block;
+
+    public BelTKwp(IBelTWideBlock block)
+    {
+        _block = block ?? throw new ArgumentNullException(nameof(block));
+    }
+
+    public void Protect(ReadOnlySpan<byte> x, ReadOnlySpan<byte> i, ReadOnlySpan<byte> k, Span<byte> y)
+    {
+        // 1. Валидация входных данных (fail-fast)
+        if (x.Length < 16) throw new ArgumentException("Ключ X слишком короткий.");
+        if (i.Length != 16) throw new ArgumentException("Заголовок I должен быть 128 бит.");
+
+        // 2. Безопасное выделение памяти
+        // Используем stackalloc для предотвращения попадания ключа в кучу (GC)
+        // y.Length всегда >= 32 байт, так что это безопасно для стека
+        Span<byte> z = stackalloc byte[y.Length];
+
+        try
+        {
+            x.CopyTo(z[..x.Length]);
+            i.CopyTo(z[x.Length..]);
+
+            // 3. Вызов широкоблочного шифра (Шаг 1: Y ← belt-wblock(Z, K))
+            _block.Encrypt(z, k, y);
+        }
+        finally
+        {
+            // Стираем промежуточную склейку Z из памяти сразу после использования
+            CryptographicOperations.ZeroMemory(z);
+        }
+    }
+
+    public bool Unprotect(ReadOnlySpan<byte> y, ReadOnlySpan<byte> i, ReadOnlySpan<byte> k, Span<byte> x)
+    {
+        // Шаг 1: Проверка длины и кратности (минимум 32 байта)
+        if (y.Length < 32 || (y.Length % 16 != 0))
+        {
+            if (x.Length > 0) x.Clear();
+            return false;
+        }
+
+        // Временный буфер для расшифрованного Z = (X || r)
+        Span<byte> z = stackalloc byte[y.Length];
+
+        try
+        {
+            // Шаг 2: (X || r) ← belt-wblock⁻¹(Y, K)
+            _block.Decrypt(y, k, z);
+
+            int xLen = y.Length - 16;
+            ReadOnlySpan<byte> restoredX = z[..xLen];
+            ReadOnlySpan<byte> r = z[xLen..];
+
+            // Шаг 3: Если r != I, то возвратить ⊥ (false)
+            if (!CryptographicOperations.FixedTimeEquals(r, i))
+            {
+                if (x.Length > 0) x.Clear();
+                return false;
+            }
+
+            // Шаг 4: Возвратить X
+            // Если проверка пройдена, копируем результат в выходной Span
+            restoredX.CopyTo(x);
+            return true;
+        }
+        finally
+        {
+            // Очистка всех копий секретного ключа в памяти стека
+            CryptographicOperations.ZeroMemory(z);
+        }
+    }
+}

--- a/BelTCrypto.Core/BelTWideBlock.cs
+++ b/BelTCrypto.Core/BelTWideBlock.cs
@@ -5,7 +5,7 @@ namespace BelTCrypto.Core;
 
 internal class BelTWideBlock : IBelTWideBlock
 {
-    private IBelTBlock _block;
+    private readonly IBelTBlock _block;
 
     public BelTWideBlock(IBelTBlock block)
     {

--- a/BelTCrypto.Core/Factories/BelTKwpFactory.cs
+++ b/BelTCrypto.Core/Factories/BelTKwpFactory.cs
@@ -1,0 +1,8 @@
+﻿using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Core.Factories;
+
+public static class BelTKwpFactory
+{
+    public static IBelTKwp Create() => new BelTKwp(BelTBlockFactory.CreateWide());
+}

--- a/BelTCrypto.Core/Interfaces/IBelTKwp.cs
+++ b/BelTCrypto.Core/Interfaces/IBelTKwp.cs
@@ -1,0 +1,23 @@
+﻿namespace BelTCrypto.Core.Interfaces;
+
+public interface IBelTKwp
+{
+    /// <summary>
+    /// Установка защиты ключа (belt-kwp)
+    /// </summary>
+    /// <param name="x">Защищаемый ключ (длина >= 16 байт)</param>
+    /// <param name="i">Заголовок (ровно 16 байт)</param>
+    /// <param name="k">Ключ защиты (32 байта)</param>
+    /// <param name="y">Выходной защищенный ключ (длина x.Length + 16)</param>
+    void Protect(ReadOnlySpan<byte> x, ReadOnlySpan<byte> i, ReadOnlySpan<byte> k, Span<byte> y);
+
+    /// <summary>
+    /// Снятие защиты ключа (belt-kwp-1)
+    /// </summary>
+    /// <param name="y">Защищенный ключ</param>
+    /// <param name="i">Ожидаемый заголовок (16 байт)</param>
+    /// <param name="k">Ключ защиты (32 байта)</param>
+    /// <param name="x">Выходной исходный ключ (длина y.Length - 16)</param>
+    /// <returns>True, если целостность подтверждена; иначе False (⊥)</returns>
+    bool Unprotect(ReadOnlySpan<byte> y, ReadOnlySpan<byte> i, ReadOnlySpan<byte> k, Span<byte> x);
+}

--- a/BelTCrypto.Tests/BelTKwpTests.cs
+++ b/BelTCrypto.Tests/BelTKwpTests.cs
@@ -1,0 +1,70 @@
+﻿using BelTCrypto.Core.Factories;
+using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Tests;
+
+[TestFixture]
+internal class BelTKwpTests
+{
+    private IBelTKwp _kwp;
+
+    [SetUp]
+    public void Setup() => _kwp = BelTKwpFactory.Create();
+
+    [Test]
+    public void Protect_TableA21_KeyWrap()
+    {
+        // Данные из Таблицы А.21
+        var x = Core.BelTMath.H[..32];
+        var i = Core.BelTMath.H[32..48];
+        var k = Core.BelTMath.H[128..160];
+
+        var expectedY = new byte[] {
+            0x49, 0xA3, 0x8E, 0xE1, 0x08, 0xD6, 0xC7, 0x42, 
+            0xE5, 0x2B, 0x77, 0x4F, 0x00, 0xA6, 0xEF, 0x98, 
+            0xB1, 0x06, 0xCB, 0xD1, 0x3E, 0xA4, 0xFB, 0x06, 
+            0x80, 0x32, 0x30, 0x51, 0xBC, 0x04, 0xDF, 0x76,
+            0xE4, 0x87, 0xB0, 0x55, 0xC6, 0x9B, 0xCF, 0x54, 
+            0x11, 0x76, 0x16, 0x9F, 0x1D, 0xC9, 0xF6, 0xC8
+        };
+
+        var actualY = new byte[x.Length + 16];
+        _kwp.Protect(x, i, k, actualY);
+
+        TestContext.Out.WriteLine($"Actual Y:   {BitConverter.ToString(actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {BitConverter.ToString(expectedY)}");
+
+        Assert.That(actualY, Is.EqualTo(expectedY), "KWP Protect (Table A.21) failed");
+    }
+
+    [Test]
+    public void Unprotect_TableA22_KeyUnwrap()
+    {
+        // Данные из Таблицы А.22
+        var y = Core.BelTMath.H[64..112];
+        var i = new byte[] {
+            0xB5, 0xEF, 0x68, 0xD8, 0xE4, 0xA3, 0x9E, 0x56, 
+            0x71, 0x53, 0xDE, 0x13, 0xD7, 0x22, 0x54, 0xEE
+        };
+        var k = Core.BelTMath.H[160..192];
+
+        var expectedX = new byte[] {
+            0x92, 0x63, 0x2E, 0xE0, 0xC2, 0x1A, 0xD9, 0xE0, 
+            0x9A, 0x39, 0x34, 0x3E, 0x5C, 0x07, 0xDA, 0xA4, 
+            0x88, 0x9B, 0x03, 0xF2, 0xE6, 0x84, 0x7E, 0xB1, 
+            0x52, 0xEC, 0x99, 0xF7, 0xA4, 0xD9, 0xF1, 0x54
+        };
+
+        var actualX = new byte[y.Length - 16];
+        bool isValid = _kwp.Unprotect(y, i, k, actualX);
+
+        TestContext.Out.WriteLine($"Actual X:   {BitConverter.ToString(actualX)}");
+        TestContext.Out.WriteLine($"Expected X: {BitConverter.ToString(expectedX)}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(isValid, Is.True, "KWP Unprotect integrity check failed");
+            Assert.That(actualX, Is.EqualTo(expectedX), "KWP Unprotect (Table A.22) data mismatch");
+        });
+    }
+}


### PR DESCRIPTION
- Added BelTKwp class for authenticated key encryption.
- Implemented Protect (7.7.3) and Unprotect (7.7.4) algorithms.
- Integrated safety measures: stackalloc for secrets and CryptographicOperations.ZeroMemory.
- Added constant-time verification for header (I) integrity check.
- Added NUnit tests based on official vectors (Table A.21, A.22).
- Defined dependency on IBelTWideBlock (6.2) for wide-block transformations.

ref-on: Implement Key Wrap Mode (belt-kwp)
https://github.com/PiterPoker/BelTCrypto.Net/issues/15