### PR TITLE
feat: implement belt-hash according to STB 34.101.31-2020

### DIFF
--- a/BelTCrypto.Core/BeltHash.cs
+++ b/BelTCrypto.Core/BeltHash.cs
@@ -1,26 +1,94 @@
-﻿using BelTCrypto.Core.Interfaces.Old;
-using BelTCrypto.Core.Old;
+﻿using System.Buffers.Binary;
 using System.Security.Cryptography;
+using BelTCrypto.Core.Interfaces;
 
 namespace BelTCrypto.Core;
 
-public static class BeltHash
+/// <summary>
+/// Реализация алгоритма хэширования belt-hash согласно СТБ 34.101.31-2020 (п. 7.8).
+/// </summary>
+internal sealed class BelTHash : IBelTHash
 {
-    public static byte SubstituteH(byte b) => BelTMathOld.SubstituteH(b);
-    public static uint RotHi(uint value, int bits) => BelTMathOld.RotHi(value, bits);
-    public static void MultiplyGF128(Span<byte> t, ReadOnlySpan<byte> r) => BelTMathOld.MultiplyGF128(t, r);
-    public static IBelTBlockOld BelTBlock() => new BelTBlockOld();
-    public static IBelTBlockOld BelTBlock(ReadOnlySpan<byte> key) => new BelTBlockOld(key);
-    public static IBelTWideBlockOld BelTWideBlock(IBelTBlockOld block) => new BelTWideBlockOld(block);
-    public static IBelTCompressOld BelTCompress(IBelTBlockOld block) => new BelTCompressOld(block);
-    public static IBelTEcbTransformOld BelTEcbEncryptTransform(IBelTBlockOld block) => new BelTEcbEncryptTransformOld(block);
-    public static IBelTEcbTransformOld BelTEcbDecryptTransform(IBelTBlockOld block) => new BelTEcbDecryptTransformOld(block);
-    public static IBelTCbcOldTransform BelTCbcEncryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCbcEncryptOldTransform(block, iv);
-    public static IBelTCbcOldTransform BelTCbcDecryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCbcDecryptOldTransform(block, iv); 
-    public static IBelTCfbOldTransform BelTCfbEncryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCfbEncryptOldTransform(block, iv);
-    public static IBelTCfbOldTransform BelTCfbDecryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCfbDecryptOldTransform(block, iv);
-    public static IBelTCrtOldTransform BelTCtrTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCtrOldTransform(block, iv);
-    public static IBelTMacOld BelTMac(IBelTBlockOld block) => new BelTMacOld(block);
+    private readonly IBelTCompress _compressor;
+    private const int HashSize = 32;       // 256 бит
+    private const int MessageBlockSize = 32; // 256 бит (п. 7.8.3, шаг 1)
 
-    public static IBelTAeadOld BelTDwp(IBelTBlockOld block)=> new BelTDwpOld(block);
+    public BelTHash(IBelTCompress compressor)
+    {
+        _compressor = compressor ?? throw new ArgumentNullException(nameof(compressor));
+    }
+
+    public void ComputeHash(ReadOnlySpan<byte> x, Span<byte> y)
+    {
+        if (y.Length != HashSize)
+            throw new ArgumentException($"Размер буфера Y должен быть {HashSize} байт (256 бит).", nameof(y));
+
+        // --- 7.8.2 Переменные ---
+        Span<byte> r = stackalloc byte[16]; // Длина сообщения (128 бит)
+        Span<byte> s = stackalloc byte[16]; // Контрольная сумма (128 бит)
+        Span<byte> t = stackalloc byte[16]; // Промежуточный результат t
+        Span<byte> h = stackalloc byte[32]; // Текущее состояние хэша (256 бит)
+
+        // Буферы для работы компрессора
+        Span<byte> compressInput = stackalloc byte[64];
+        Span<byte> currentBlock = compressInput[..32]; // Xi
+
+        try
+        {
+            // --- 7.8.3 Шаг 2: Установить ---
+
+            // 2.1) r ← ⟨|X|⟩_128 (Длина в битах)
+            r.Clear();
+            BinaryPrimitives.WriteUInt64LittleEndian(r, (ulong)x.Length * 8);
+
+            // 2.2) s ← 0^128
+            s.Clear();
+
+            // 2.3) h ← IV (Константа из таблицы 2)
+            BelTMath.H[..32].CopyTo(h);
+
+            // --- 7.8.3 Шаг 1: Split(X, 256) ---
+            int n = (x.Length + MessageBlockSize - 1) / MessageBlockSize;
+
+            // --- 7.8.3 Шаг 3: Цикл (выполняется, если сообщение не пустое) ---
+            for (int i = 0; i < n; i++)
+            {
+                int offset = i * MessageBlockSize;
+                int remaining = x.Length - offset;
+                int copyLen = Math.Min(remaining, MessageBlockSize);
+
+                // 2.4) Xn ← Xn ‖ 0 (Дополнение нулями до 256 бит)
+                currentBlock.Clear();
+                x.Slice(offset, copyLen).CopyTo(currentBlock);
+
+                // 3.1) (t, h) ← belt-compress(Xi ‖ h)
+                // Xi уже в первых 32 байтах compressInput, копируем h во вторые 32 байта
+                h.CopyTo(compressInput[32..]);
+
+                _compressor.Compress(compressInput, t, h);
+
+                // 3.2) s ← s ⊕ t
+                BelTMath.GfBlock.Xor(s, t);
+            }
+
+            // --- 7.8.3 Шаг 4: Финализация ---
+            // (⊥, Y) ← belt-compress(r ‖ s ‖ h)
+            Span<byte> finalInput = stackalloc byte[64];
+            r.CopyTo(finalInput[0..16]);
+            s.CopyTo(finalInput[16..32]);
+            h.CopyTo(finalInput[32..64]);
+
+            // Результат записывается напрямую в выходной буфер y
+            _compressor.Compress(finalInput, t, y);
+        }
+        finally
+        {
+            // Очистка КИЗИ (Конфиденциальной информации)
+            CryptographicOperations.ZeroMemory(r);
+            CryptographicOperations.ZeroMemory(s);
+            CryptographicOperations.ZeroMemory(t);
+            CryptographicOperations.ZeroMemory(h);
+            CryptographicOperations.ZeroMemory(compressInput);
+        }
+    }
 }

--- a/BelTCrypto.Core/Factories/BelTHashFactory.cs
+++ b/BelTCrypto.Core/Factories/BelTHashFactory.cs
@@ -1,0 +1,8 @@
+﻿using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Core.Factories;
+
+public static class BelTHashFactory
+{
+    public static IBelTHash Create() => new BelTHash(BelTCompressorFactory.Create());
+}

--- a/BelTCrypto.Core/Interfaces/IBelTHash.cs
+++ b/BelTCrypto.Core/Interfaces/IBelTHash.cs
@@ -1,0 +1,14 @@
+﻿namespace BelTCrypto.Core.Interfaces;
+
+/// <summary>
+/// Интерфейс алгоритма хэширования belt-hash (СТБ 34.101.31)
+/// </summary>
+public interface IBelTHash
+{
+    /// <summary>
+    /// Вычисляет хэш-значение Y для сообщения X.
+    /// </summary>
+    /// <param name="x">Входное сообщение X произвольной длины.</param>
+    /// <param name="y">Выходной хэш Y (256 бит / 32 байта).</param>
+    void ComputeHash(ReadOnlySpan<byte> x, Span<byte> y);
+}

--- a/BelTCrypto.Core/Old/BeltHashOld.cs
+++ b/BelTCrypto.Core/Old/BeltHashOld.cs
@@ -1,0 +1,25 @@
+﻿using BelTCrypto.Core.Interfaces.Old;
+using System.Security.Cryptography;
+
+namespace BelTCrypto.Core.Old;
+
+public static class BeltHashOld
+{
+    public static byte SubstituteH(byte b) => BelTMathOld.SubstituteH(b);
+    public static uint RotHi(uint value, int bits) => BelTMathOld.RotHi(value, bits);
+    public static void MultiplyGF128(Span<byte> t, ReadOnlySpan<byte> r) => BelTMathOld.MultiplyGF128(t, r);
+    public static IBelTBlockOld BelTBlock() => new BelTBlockOld();
+    public static IBelTBlockOld BelTBlock(ReadOnlySpan<byte> key) => new BelTBlockOld(key);
+    public static IBelTWideBlockOld BelTWideBlock(IBelTBlockOld block) => new BelTWideBlockOld(block);
+    public static IBelTCompressOld BelTCompress(IBelTBlockOld block) => new BelTCompressOld(block);
+    public static IBelTEcbTransformOld BelTEcbEncryptTransform(IBelTBlockOld block) => new BelTEcbEncryptTransformOld(block);
+    public static IBelTEcbTransformOld BelTEcbDecryptTransform(IBelTBlockOld block) => new BelTEcbDecryptTransformOld(block);
+    public static IBelTCbcOldTransform BelTCbcEncryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCbcEncryptOldTransform(block, iv);
+    public static IBelTCbcOldTransform BelTCbcDecryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCbcDecryptOldTransform(block, iv); 
+    public static IBelTCfbOldTransform BelTCfbEncryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCfbEncryptOldTransform(block, iv);
+    public static IBelTCfbOldTransform BelTCfbDecryptTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCfbDecryptOldTransform(block, iv);
+    public static IBelTCrtOldTransform BelTCtrTransform(IBelTBlockOld block, ReadOnlySpan<byte> iv) => new BelTCtrOldTransform(block, iv);
+    public static IBelTMacOld BelTMac(IBelTBlockOld block) => new BelTMacOld(block);
+
+    public static IBelTAeadOld BelTDwp(IBelTBlockOld block)=> new BelTDwpOld(block);
+}

--- a/BelTCrypto.Net/BelTAlgorithm.cs
+++ b/BelTCrypto.Net/BelTAlgorithm.cs
@@ -1,5 +1,5 @@
-﻿using BelTCrypto.Core;
-using BelTCrypto.Core.Interfaces.Old;
+﻿using BelTCrypto.Core.Interfaces.Old;
+using BelTCrypto.Core.Old;
 using System.Security.Cryptography;
 
 namespace BelTCrypto.Net;
@@ -30,10 +30,10 @@ public class BelTAlgorithm : SymmetricAlgorithm
         // Вот здесь происходит переключение режимов
         return Mode switch
         {
-            CipherMode.ECB => BeltHash.BelTEcbEncryptTransform(block),
-            CipherMode.CBC => BeltHash.BelTCbcEncryptTransform(block, rgbIV ?? IV),
-            CipherMode.CFB => BeltHash.BelTCfbEncryptTransform(block, rgbIV ?? IV),
-            BelTModes.CTR => BeltHash.BelTCtrTransform(block, rgbIV ?? IV),
+            CipherMode.ECB => BeltHashOld.BelTEcbEncryptTransform(block),
+            CipherMode.CBC => BeltHashOld.BelTCbcEncryptTransform(block, rgbIV ?? IV),
+            CipherMode.CFB => BeltHashOld.BelTCfbEncryptTransform(block, rgbIV ?? IV),
+            BelTModes.CTR => BeltHashOld.BelTCtrTransform(block, rgbIV ?? IV),
             // Сюда потом добавим CTR, CFB и т.д.
             _ => throw new CryptographicException($"Режим {Mode} не поддерживается для BelT")
         };
@@ -62,10 +62,10 @@ public class BelTAlgorithm : SymmetricAlgorithm
 
         return Mode switch
         {
-            CipherMode.ECB => BeltHash.BelTEcbDecryptTransform(block),
-            CipherMode.CBC => BeltHash.BelTCbcDecryptTransform(block, rgbIV ?? IV),
-            CipherMode.CFB => BeltHash.BelTCfbDecryptTransform(block, rgbIV ?? IV),
-            BelTModes.CTR => BeltHash.BelTCtrTransform(block, rgbIV ?? IV),
+            CipherMode.ECB => BeltHashOld.BelTEcbDecryptTransform(block),
+            CipherMode.CBC => BeltHashOld.BelTCbcDecryptTransform(block, rgbIV ?? IV),
+            CipherMode.CFB => BeltHashOld.BelTCfbDecryptTransform(block, rgbIV ?? IV),
+            BelTModes.CTR => BeltHashOld.BelTCtrTransform(block, rgbIV ?? IV),
             _ => throw new CryptographicException($"Режим {Mode} не поддерживается для BelT")
         };
     }

--- a/BelTCrypto.Net/BelTCbcAlgorithm.cs
+++ b/BelTCrypto.Net/BelTCbcAlgorithm.cs
@@ -1,5 +1,5 @@
-﻿using BelTCrypto.Core;
-using BelTCrypto.Core.Interfaces.Old;
+﻿using BelTCrypto.Core.Interfaces.Old;
+using BelTCrypto.Core.Old;
 using System.Security.Cryptography;
 
 namespace BelTCrypto.Net;
@@ -31,7 +31,7 @@ public sealed class BelTCbcAlgorithm : SymmetricAlgorithm
             throw new ArgumentException("IV must be 128 bits", nameof(rgbIV));
 
         var block = _blockFactory(rgbKey);
-        return BeltHash.BelTCbcEncryptTransform(block, rgbIV);
+        return BeltHashOld.BelTCbcEncryptTransform(block, rgbIV);
     }
 
     public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[]? rgbIV)
@@ -40,7 +40,7 @@ public sealed class BelTCbcAlgorithm : SymmetricAlgorithm
             throw new ArgumentException("IV must be 128 bits", nameof(rgbIV));
 
         var block = _blockFactory(rgbKey);
-        return BeltHash.BelTCbcDecryptTransform(block, rgbIV);
+        return BeltHashOld.BelTCbcDecryptTransform(block, rgbIV);
     }
 
     // Эти методы обязательны для реализации абстрактного класса

--- a/BelTCrypto.Net/BelTMac.cs
+++ b/BelTCrypto.Net/BelTMac.cs
@@ -1,5 +1,5 @@
-﻿using BelTCrypto.Core;
-using BelTCrypto.Core.Interfaces.Old;
+﻿using BelTCrypto.Core.Interfaces.Old;
+using BelTCrypto.Core.Old;
 using System.Security.Cryptography;
 
 namespace BelTCrypto.Net;
@@ -13,8 +13,8 @@ public sealed class BelTMac : KeyedHashAlgorithm
     public BelTMac(byte[] key)
     {
         // Используем твою фабрику из Core
-        var block = BeltHash.BelTBlock(key);
-        _engine = BeltHash.BelTMac(block);
+        var block = BeltHashOld.BelTBlock(key);
+        _engine = BeltHashOld.BelTMac(block);
         HashSizeValue = 64;
     }
 

--- a/BelTCrypto.Net/BeltAead.cs
+++ b/BelTCrypto.Net/BeltAead.cs
@@ -1,5 +1,5 @@
-﻿using BelTCrypto.Core;
-using BelTCrypto.Core.Interfaces.Old;
+﻿using BelTCrypto.Core.Interfaces.Old;
+using BelTCrypto.Core.Old;
 using System.Security.Cryptography;
 
 namespace BelTCrypto.Net;
@@ -15,11 +15,11 @@ public sealed class BeltAead : IDisposable
         if (key.Length != 32) throw new ArgumentException("Ключ BelT должен быть 256 бит (32 байта).");
 
         // Инициализируем Core-движок через нашу фабрику
-        var block = BeltHash.BelTBlock(key); // Твой класс реализации блочного шифра
+        var block = BeltHashOld.BelTBlock(key); // Твой класс реализации блочного шифра
 
         _engine = scheme switch
         {
-            BeltAeadScheme.Dwp => BeltHash.BelTDwp(block),
+            BeltAeadScheme.Dwp => BeltHashOld.BelTDwp(block),
             // BelTChe добавим позже
             _ => throw new NotSupportedException($"Схема {scheme} еще не реализована.")
         };

--- a/BelTCrypto.Tests/BelTAlgorithmTests.cs
+++ b/BelTCrypto.Tests/BelTAlgorithmTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 using BelTCrypto.Net;
 using System.Security.Cryptography;
 
@@ -15,7 +15,7 @@ internal class BelTAlgorithmTests
         string expectedY = "69CCA1C93557C9E3D66BC3E0FA88FA6E36F00CFED6D1CA1498C12798F4BEB2075F23102EF109710775017F73806DA9";
 
         // 1. Создаем алгоритм
-        using var algo = new BelTAlgorithm(k => BeltHash.BelTBlock(k));
+        using var algo = new BelTAlgorithm(k => BeltHashOld.BelTBlock(k));
         algo.Mode = CipherMode.ECB; // Переключаем режим
         algo.Padding = PaddingMode.None;
 
@@ -37,7 +37,7 @@ internal class BelTAlgorithmTests
         byte[] x = Convert.FromHexString("B194BAC80A08F53B366D008E584A5DE48504FA9D1BB6C7AC252E72C202FDCE0D5BE3D612");
         string expectedY = "10116EFAE6AD58EE14852E11DA1B8A746A9BBADCAF73F968F875DEDC0A44F6B15CF2480E";
 
-        using var algo = new BelTAlgorithm(k => BeltHash.BelTBlock(k));
+        using var algo = new BelTAlgorithm(k => BeltHashOld.BelTBlock(k));
         algo.Mode = CipherMode.CBC;
 
         using var ms = new MemoryStream();

--- a/BelTCrypto.Tests/BelTHashTests.cs
+++ b/BelTCrypto.Tests/BelTHashTests.cs
@@ -1,0 +1,82 @@
+﻿using BelTCrypto.Core.Factories;
+using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Tests;
+
+[TestFixture]
+internal class BelTHashTests
+{
+    private IBelTHash _hash;
+
+    [SetUp]
+    public void Setup() => _hash = BelTHashFactory.Create();
+
+    [Test]
+    public void Hash_TableA23_Vector1_Short()
+    {
+        // X = B194BAC8 0A08F53B 366D008E 58 (13 байт)
+        var x = Core.BelTMath.H[..13];
+
+        var expectedY = new byte[]
+        {
+            0xAB, 0xEF, 0x97, 0x25, 0xD4, 0xC5, 0xA8, 0x35, 
+            0x97, 0xA3, 0x67, 0xD1, 0x44, 0x94, 0xCC, 0x25, 
+            0x42, 0xF2, 0x0F, 0x65, 0x9D, 0xDF, 0xEC, 0xC9, 
+            0x61, 0xA3, 0xEC, 0x55, 0x0C, 0xBA, 0x8C, 0x75
+        };
+
+        var actualY = new byte[32];
+        _hash.ComputeHash(x, actualY);
+
+        TestContext.Out.WriteLine($"Actual Y:   {BitConverter.ToString(actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {BitConverter.ToString(expectedY)}");
+
+        Assert.That(actualY, Is.EqualTo(expectedY), "Hash Vector 1 (Short) failed");
+    }
+
+    [Test]
+    public void Hash_TableA23_Vector2_FullBlock()
+    {
+        // X = B194BAC8 0A08F53B 366D008E 584A5DE4 8504FA9D 1BB6C7AC 252E72C2 02FDCE0D (32 байта)
+        var x = Core.BelTMath.H[..32];
+
+        var expectedY = new byte[]
+        {
+            0x74, 0x9E, 0x4C, 0x36, 0x53, 0xAE, 0xCE, 0x5E, 
+            0x48, 0xDB, 0x47, 0x61, 0x22, 0x77, 0x42, 0xEB, 
+            0x6D, 0xBE, 0x13, 0xF4, 0xA8, 0x0F, 0x7B, 0xEF, 
+            0xF1, 0xA9, 0xCF, 0x8D, 0x10, 0xEE, 0x77, 0x86
+        };
+
+        var actualY = new byte[32];
+        _hash.ComputeHash(x, actualY);
+
+        TestContext.Out.WriteLine($"Actual Y:   {BitConverter.ToString(actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {BitConverter.ToString(expectedY)}");
+
+        Assert.That(actualY, Is.EqualTo(expectedY), "Hash Vector 2 (Full Block) failed");
+    }
+
+    [Test]
+    public void Hash_TableA23_Vector3_Long()
+    {
+        // X = B194BAC8...02FDCE0D (32 байта) + 5BE3D612 17B96181 FE6786AD 716B890B (12 байт) = 44 байта
+        var x = Core.BelTMath.H[..48];
+
+        var expectedY = new byte[]
+        {
+            0x9D, 0x02, 0xEE, 0x44, 0x6F, 0xB6, 0xA2, 0x9F, 
+            0xE5, 0xC9, 0x82, 0xD4, 0xB1, 0x3A, 0xF9, 0xD3, 
+            0xE9, 0x08, 0x61, 0xBC, 0x4C, 0xEF, 0x27, 0xCF, 
+            0x30, 0x6B, 0xFB, 0x0B, 0x17, 0x4A, 0x15, 0x4A
+        };
+
+        var actualY = new byte[32];
+        _hash.ComputeHash(x, actualY);
+
+        TestContext.Out.WriteLine($"Actual Y:   {BitConverter.ToString(actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {BitConverter.ToString(expectedY)}");
+
+        Assert.That(actualY, Is.EqualTo(expectedY), "Hash Vector 3 (Long) failed");
+    }
+}

--- a/BelTCrypto.Tests/BelTMathTests.cs
+++ b/BelTCrypto.Tests/BelTMathTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 using BelTCrypto.Net;
 
 namespace BelTCrypto.Tests;
@@ -12,7 +12,7 @@ public class BelTMathTests
         // Пример из стандарта: H(A2) = 9B
         byte input = 0xA2;
         byte expected = 0x9B;
-        Assert.That(BeltHash.SubstituteH(input), Is.EqualTo(expected));
+        Assert.That(BeltHashOld.SubstituteH(input), Is.EqualTo(expected));
     }
 
     [Test]
@@ -22,7 +22,7 @@ public class BelTMathTests
         uint value = 0xB194BAC8;
         // В стандарте RotHi определен как циклический сдвиг влево
         uint expected = (value << 1) | (value >> 31);
-        Assert.That(BeltHash.RotHi(value, 1), Is.EqualTo(expected));
+        Assert.That(BeltHashOld.RotHi(value, 1), Is.EqualTo(expected));
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class BelTMathTests
         // Ожидаемый u*v: 0001D107 FC67DE40 04DC2C80 3DFD95C3
         byte[] expected = [.. Convert.FromHexString("0001D107FC67DE4004DC2C803DFD95C3")];
 
-        BeltHash.MultiplyGF128(u, v);
+        BeltHashOld.MultiplyGF128(u, v);
 
         Assert.That(u, Is.EqualTo(expected), "Ошибка в первом примере умножения А.18");
 
@@ -46,7 +46,7 @@ public class BelTMathTests
         byte[] v2 = [.. Convert.FromHexString("2055704E2EDB48FE87E74075A5E77EB1")];
         byte[] expected2 = [.. Convert.FromHexString("4A5C95938B3FE8F674D59BC1EB356079")];
 
-        BeltHash.MultiplyGF128(u2, v2);
+        BeltHashOld.MultiplyGF128(u2, v2);
 
         Assert.That(u2, Is.EqualTo(expected2), "Ошибка во втором примере умножения А.18");
     }

--- a/BelTCrypto.Tests/Old/BelTBlockOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTBlockOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 
 namespace BelTCrypto.Tests.Old;
 
@@ -13,7 +13,7 @@ public class BelTBlockOldTests
         byte[] x = StringToByteArray("B194BAC80A08F53B366D008E584A5DE4");
         byte[] expectedY = StringToByteArray("69CCA1C93557C9E3D66BC3E0FA88FA6E");
 
-        var engine = BeltHash.BelTBlock(key);
+        var engine = BeltHashOld.BelTBlock(key);
         Span<byte> actualY = stackalloc byte[16];
         engine.Encrypt(x, actualY);
 
@@ -28,7 +28,7 @@ public class BelTBlockOldTests
         byte[] y = StringToByteArray("E12BDC1AE28257EC703FCCF095EE8DF1");
         byte[] expectedX = StringToByteArray("0DC5300600CAB840B38448E5E993F421");
 
-        var engine = BeltHash.BelTBlock(key);
+        var engine = BeltHashOld.BelTBlock(key);
         Span<byte> actualX = stackalloc byte[16];
         engine.Decrypt(y, actualX);
 

--- a/BelTCrypto.Tests/Old/BelTCbcDecryptOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTCbcDecryptOldTests.cs
@@ -1,5 +1,5 @@
-﻿using BelTCrypto.Core;
-using BelTCrypto.Core.Interfaces.Old;
+﻿using BelTCrypto.Core.Interfaces.Old;
+using BelTCrypto.Core.Old;
 using System.Security.Cryptography;
 
 namespace BelTCrypto.Tests.Old;
@@ -10,7 +10,7 @@ public class BelTCbcDecryptOldTests
     // Вспомогательный метод для расшифрования через стандартные потоки
     private byte[] DecryptThroughStream(IBelTBlockOld block, byte[] iv, byte[] ciphertext)
     {
-        using var decryptor = BeltHash.BelTCbcDecryptTransform(block, iv);
+        using var decryptor = BeltHashOld.BelTCbcDecryptTransform(block, iv);
         using var msInput = new MemoryStream(ciphertext);
         using var msOutput = new MemoryStream();
 
@@ -32,7 +32,7 @@ public class BelTCbcDecryptOldTests
         byte[] y = Convert.FromHexString("E12BDC1AE28257EC703FCCF095EE8DF1C1AB76389FE678CAF7C6F860D5BB9C4FF33C657B637C306ADD4EA7799EB23D31");
         string expectedX = "730894D6158E17CC1600185A8F411CAB0471FF85C83792398D8924EBD57D03DB95B97A9B7907E4B020960455E46176F8";
 
-        var block = BeltHash.BelTBlock(key);
+        var block = BeltHashOld.BelTBlock(key);
         byte[] actualX = DecryptThroughStream(block, s, y);
 
         Assert.That(Convert.ToHexString(actualX), Is.EqualTo(expectedX), "Расшифрование полных блоков (48 байт) не совпало.");
@@ -51,7 +51,7 @@ public class BelTCbcDecryptOldTests
         // X = 36 байт
         string expectedX = "730894D6158E17CC1600185A8F411CABB6AB7AF8541CF85755B8EA27239F08D2166646E4";
 
-        var block = BeltHash.BelTBlock(key);
+        var block = BeltHashOld.BelTBlock(key);
         byte[] actualX = DecryptThroughStream(block, s, y);
 
         using (Assert.EnterMultipleScope())

--- a/BelTCrypto.Tests/Old/BelTCbcEncryptOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTCbcEncryptOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 using System.Security.Cryptography;
 
 namespace BelTCrypto.Tests.Old;
@@ -21,8 +21,8 @@ public class BelTCbcEncryptOldTests
         byte[] x = StringToByteArray("B194BAC80A08F53B366D008E584A5DE48504FA9D1BB6C7AC252E72C202FDCE0D5BE3D61217B96181FE6786AD716B890B");
         string expectedY = "10116EFAE6AD58EE14852E11DA1B8A745CF2480E8D03F1C19492E53ED3A70F60657C1EE8C0E0AE5B58388BF8A68E3309";
 
-        var block = BeltHash.BelTBlock(key);
-        var transform = BeltHash.BelTCbcEncryptTransform(block, s);
+        var block = BeltHashOld.BelTBlock(key);
+        var transform = BeltHashOld.BelTCbcEncryptTransform(block, s);
 
         // 3. Шифрование через поток
         using var msInput = new MemoryStream(x);
@@ -51,8 +51,8 @@ public class BelTCbcEncryptOldTests
         string expectedY = "10116EFAE6AD58EE14852E11DA1B8A746A9BBADCAF73F968F875DEDC0A44F6B15CF2480E";
 
 
-        var block = BeltHash.BelTBlock(key);
-        var transform = BeltHash.BelTCbcEncryptTransform(block, s);
+        var block = BeltHashOld.BelTBlock(key);
+        var transform = BeltHashOld.BelTCbcEncryptTransform(block, s);
 
         // 3. Шифрование через поток
         using var msInput = new MemoryStream(x);

--- a/BelTCrypto.Tests/Old/BelTCfbOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTCfbOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 using BelTCrypto.Net;
 using System.Security.Cryptography;
 
@@ -25,7 +25,7 @@ public class BelTCfbOldTests
         string expectedY = "C31E490A90EFA374626CC99E4B7B8540A6E48685464A5A06849C9CA769A1B0AE55C2CC5939303EC832DD2FE16C8E5A1B";
 
         // Настраиваем алгоритм
-        using var algo = new BelTAlgorithm(k => BeltHash.BelTBlock(k));
+        using var algo = new BelTAlgorithm(k => BeltHashOld.BelTBlock(k));
         algo.Mode = CipherMode.CFB;
         algo.Padding = PaddingMode.None;
 
@@ -47,7 +47,7 @@ public class BelTCfbOldTests
         byte[] y = Convert.FromHexString("E12BDC1AE28257EC703FCCF095EE8DF1C1AB76389FE678CAF7C6F860D5BB9C4FF33C657B637C306ADD4EA7799EB23D31");
         string expectedX = "FA9D107A86F375EE65CD1DB881224BD016AFF814938ED39B3361ABB0BF0851B652244EB06842DD4C94AA4500774E40BB";
 
-        using var algo = new BelTAlgorithm(k => BeltHash.BelTBlock(k));
+        using var algo = new BelTAlgorithm(k => BeltHashOld.BelTBlock(k));
         algo.Mode = CipherMode.CFB;
 
         using var decryptor = algo.CreateDecryptor(key, s);

--- a/BelTCrypto.Tests/Old/BelTCompressOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTCompressOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 
 namespace BelTCrypto.Tests.Old;
 
@@ -12,8 +12,8 @@ public class BelTCompressOldTests
         string expectedS = "46FE7425C9B181EB41DFEE3E72163D5A";
         string expectedY = "ED2F5481D593F40D87FCE37D6BC1A2E1B7D1A2CC975C82D3C0497488C90D99D8";
 
-        var engine = BeltHash.BelTBlock();
-        var beltCompress = BeltHash.BelTCompress(engine);
+        var engine = BeltHashOld.BelTBlock();
+        var beltCompress = BeltHashOld.BelTCompress(engine);
         var (S, Y) = beltCompress.Compress(x);
 
         Assert.Multiple(() =>

--- a/BelTCrypto.Tests/Old/BelTCtrOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTCtrOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 using BelTCrypto.Net;
 using System.Security.Cryptography;
 
@@ -22,7 +22,7 @@ public class BelTCtrOldTests
         // Ожидаемый Y из таблицы А.15
         string expectedY = "52C9AF96FF50F64435FC43DEF56BD797D5B5B1FF79FB41257AB9CDF6E63E81F8F00341473EAE409833622DE05213773A";
 
-        using var algo = new BelTAlgorithm(k => BeltHash.BelTBlock(k));
+        using var algo = new BelTAlgorithm(k => BeltHashOld.BelTBlock(k));
         algo.Mode = CTR;
         algo.Padding = PaddingMode.None;
 
@@ -45,7 +45,7 @@ public class BelTCtrOldTests
         // Ожидаемый X из таблицы А.16
         string expectedX = "DF181ED008A20F43DCBBB93650DAD34B389CDEE5826D40E2D4BD80F49A93F5D212F6333166456F169043CC5F";
 
-        using var algo = new BelTAlgorithm(k => BeltHash.BelTBlock(k));
+        using var algo = new BelTAlgorithm(k => BeltHashOld.BelTBlock(k));
         algo.Mode = CTR;
 
         // В CTR дешифратор создается точно так же, как шифратор

--- a/BelTCrypto.Tests/Old/BelTEcbOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTEcbOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 
 namespace BelTCrypto.Tests.Old;
 
@@ -16,8 +16,8 @@ public class BelTEcbOldTests
         byte[] x = StringToByteArray("B194BAC80A08F53B366D008E584A5DE48504FA9D1BB6C7AC252E72C202FDCE0D5BE3D61217B96181FE6786AD716B890B");
         string expectedY = "69CCA1C93557C9E3D66BC3E0FA88FA6E5F23102EF109710775017F73806DA9DC46FB2ED2CE771F26DCB5E5D1569F9AB0";
 
-        using var block = BeltHash.BelTBlock(key);
-        using var encryptor = BeltHash.BelTEcbEncryptTransform(block);
+        using var block = BeltHashOld.BelTBlock(key);
+        using var encryptor = BeltHashOld.BelTEcbEncryptTransform(block);
 
         // ICryptoTransform: используем TransformFinalBlock для получения результата целиком
         byte[] actualY = encryptor.TransformFinalBlock(x, 0, x.Length);
@@ -34,8 +34,8 @@ public class BelTEcbOldTests
         byte[] x = StringToByteArray("B194BAC80A08F53B366D008E584A5DE48504FA9D1BB6C7AC252E72C202FDCE0D5BE3D61217B96181FE6786AD716B89");
         string expectedY = "69CCA1C93557C9E3D66BC3E0FA88FA6E36F00CFED6D1CA1498C12798F4BEB2075F23102EF109710775017F73806DA9";
 
-        using var block = BeltHash.BelTBlock(key);
-        using var encryptor = BeltHash.BelTEcbEncryptTransform(block);
+        using var block = BeltHashOld.BelTBlock(key);
+        using var encryptor = BeltHashOld.BelTEcbEncryptTransform(block);
 
         byte[] actualY = encryptor.TransformFinalBlock(x, 0, x.Length);
 
@@ -50,8 +50,8 @@ public class BelTEcbOldTests
         byte[] y = StringToByteArray("E12BDC1AE28257EC703FCCF095EE8DF1C1AB76389FE678CAF7C6F860D5BB9C4FF33C657B637C306ADD4EA7799EB23D31");
         string expectedX = "0DC5300600CAB840B38448E5E993F421E55A239F2AB5C5D5FDB6E81B40938E2A54120CA3E6E19C7AD750FC3531DAEAB7";
 
-        using var block = BeltHash.BelTBlock(key);
-        using var decryptor = BeltHash.BelTEcbDecryptTransform(block);
+        using var block = BeltHashOld.BelTBlock(key);
+        using var decryptor = BeltHashOld.BelTEcbDecryptTransform(block);
 
         byte[] actualX = decryptor.TransformFinalBlock(y, 0, y.Length);
 
@@ -66,8 +66,8 @@ public class BelTEcbOldTests
         byte[] y = StringToByteArray("E12BDC1AE28257EC703FCCF095EE8DF1C1AB76389FE678CAF7C6F860D5BB9C4FF33C657B");
         string expectedX = "0DC5300600CAB840B38448E5E993F4215780A6E2B69EAFBB258726D7B6718523E55A239F";
 
-        using var block = BeltHash.BelTBlock(key);
-        using var decryptor = BeltHash.BelTEcbDecryptTransform(block);
+        using var block = BeltHashOld.BelTBlock(key);
+        using var decryptor = BeltHashOld.BelTEcbDecryptTransform(block);
 
         byte[] actualX = decryptor.TransformFinalBlock(y, 0, y.Length);
 

--- a/BelTCrypto.Tests/Old/BelTWideBlockOldTests.cs
+++ b/BelTCrypto.Tests/Old/BelTWideBlockOldTests.cs
@@ -1,4 +1,4 @@
-﻿using BelTCrypto.Core;
+﻿using BelTCrypto.Core.Old;
 
 namespace BelTCrypto.Tests.Old;
 
@@ -13,8 +13,8 @@ public class BelTWideBlockOldTests
         byte[] expectedY = StringToByteArray("49A38EE108D6C742E52B774F00A6EF98B106CBD13EA4FB0680323051BC04DF76E487B055C69BCF541176169F1DC9F6C8");
 
         byte[] actualY = new byte[x.Length];
-        var engine = BeltHash.BelTBlock(key);
-        var wideBlock = BeltHash.BelTWideBlock(engine);
+        var engine = BeltHashOld.BelTBlock(key);
+        var wideBlock = BeltHashOld.BelTWideBlock(engine);
         wideBlock.Encrypt(x, actualY);
 
         Assert.That(Convert.ToHexString(actualY), Is.EqualTo(Convert.ToHexString(expectedY)));
@@ -29,8 +29,8 @@ public class BelTWideBlockOldTests
         byte[] expectedY = StringToByteArray("F08EF22DCAA06C81FB12721974221CA7AB82C62856FCF2F9FCA006E019A28F16E5821A51F573594625DBAB8F6A5C94");
 
         byte[] actualY = new byte[expectedY.Length];
-        var engine = BeltHash.BelTBlock(key);
-        var wideBlock = BeltHash.BelTWideBlock(engine);
+        var engine = BeltHashOld.BelTBlock(key);
+        var wideBlock = BeltHashOld.BelTWideBlock(engine);
 
         // Если X короче Y, нам нужно понять логику дополнения в стандарте
         // Пока пробуем как есть (если x.Length == 32)
@@ -48,8 +48,8 @@ public class BelTWideBlockOldTests
         byte[] expectedX = StringToByteArray("92632EE0C21AD9E09A39343E5C07DAA4889B03F2E6847EB152EC99F7A4D9F154B5EF68D8E4A39E567153DE13D72254EE");
 
         byte[] actualX = new byte[y.Length];
-        var engine = BeltHash.BelTBlock(key);
-        var wideBlock = BeltHash.BelTWideBlock(engine);
+        var engine = BeltHashOld.BelTBlock(key);
+        var wideBlock = BeltHashOld.BelTWideBlock(engine);
 
         wideBlock.Decrypt(y, actualX);
 
@@ -65,8 +65,8 @@ public class BelTWideBlockOldTests
         byte[] expectedX = StringToByteArray("DF3F882230BAAFFC92F05660321172310E3CB2182681EF43102E67175E177BD75E93E4E8");
 
         byte[] actualX = new byte[y.Length];
-        var engine = BeltHash.BelTBlock(key);
-        var wideBlock = BeltHash.BelTWideBlock(engine);
+        var engine = BeltHashOld.BelTBlock(key);
+        var wideBlock = BeltHashOld.BelTWideBlock(engine);
 
         wideBlock.Decrypt(y, actualX);
 


### PR DESCRIPTION
- Added BelTHash implementation with strict adherence to section 7.8.
- Fixed padding logic for the final message block (concatenation with zeros).
- Corrected 128-bit length (r) and checksum (s) calculation.
- Ensured zero-initialization of stack-allocated buffers to prevent non-deterministic hash results.
- Optimized memory usage by reusing compressInput buffer slices.
- Added ZeroMemory calls to wipe sensitive intermediate states from the stack.

ref-on: Implement Hashing Mode (belt-hash)
https://github.com/PiterPoker/BelTCrypto.Net/issues/17