### PR TITLE
feat: implement belt-bde disk encryption mode (STB 7.9.2)

### DIFF
--- a/BelTCrypto.Core/BelTBde.cs
+++ b/BelTCrypto.Core/BelTBde.cs
@@ -1,0 +1,116 @@
+﻿using BelTCrypto.Core.Interfaces;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace BelTCrypto.Core;
+
+internal class BelTBde : IBelTBde
+{
+    private readonly IBelTBlock _block;
+    private const int BlockSize = 16;
+
+    public BelTBde(IBelTBlock block)
+    {
+        _block = block ?? throw new ArgumentNullException(nameof(block));
+    }
+
+    public void Decrypt(ReadOnlySpan<byte> y, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<byte> x)
+    {
+        if (y.Length < BlockSize)
+            throw new ArgumentException("Длина данных должна быть не меньше 128 бит.");
+        if (y.Length % BlockSize != 0)
+            throw new ArgumentException("Длина данных должна быть кратна 128 битам.");
+        if (y.Length != x.Length)
+            throw new ArgumentException("Размер входного и выходного буферов должен совпадать.");
+
+        // Шаг 2: Установить s ← belt-block(S, K)
+        Span<byte> currentS = stackalloc byte[BlockSize];
+        _block.Encrypt(s, k, currentS);
+
+        // Шаг 1: Split(Y, 128)
+        int n = y.Length / BlockSize;
+
+        // Шаг 3: Цикл по i=1..n
+        for (int i = 0; i < n; i++)
+        {
+            // 3.1) s ← s * C
+            BelTMath.GfBlock.Multiply(currentS, BelTMath.C);
+
+            int offset = i * BlockSize;
+
+            // 3.2) Xi ← belt-block-1(Yi ⊕ s, K) ⊕ s
+            DecryptBlock(y.Slice(offset, BlockSize), k, currentS, x.Slice(offset, BlockSize));
+        }
+
+        // Шаг 4: Возвратить X (результат уже в x благодаря слайсам)
+        CryptographicOperations.ZeroMemory(currentS);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void DecryptBlock(
+        ReadOnlySpan<byte> input,
+        ReadOnlySpan<byte> k,
+        ReadOnlySpan<byte> s,
+        Span<byte> output)
+    {
+        Span<byte> buffer = stackalloc byte[BlockSize];
+        input.CopyTo(buffer);
+
+        // Yi ⊕ s
+        BelTMath.GfBlock.Xor(buffer, s);
+
+        // belt-block-1(..., K)
+        _block.Decrypt(buffer, k, output);
+
+        // Результат ⊕ s
+        BelTMath.GfBlock.Xor(output, s);
+    }
+
+    public void Encrypt(ReadOnlySpan<byte> x, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<byte> y)
+    {
+        if (x.Length < BlockSize)
+            throw new ArgumentException("Длина данных должна быть не меньше 128 бит.");
+        if (x.Length % BlockSize != 0)
+            throw new ArgumentException("Длина данных должна быть кратна 128 битам.");
+        if (x.Length != y.Length)
+            throw new ArgumentException("Размер входного и выходного буферов должен совпадать.");
+
+        // Шаг 2: Установить s ← belt-block(S, K)
+        Span<byte> currentS = stackalloc byte[BlockSize];
+        _block.Encrypt(s, k, currentS);
+
+        // Шаг 1: Split(X, 128)
+        int n = x.Length / BlockSize;
+
+        // Шаг 3: Цикл по i=1..n
+        for (int i = 0; i < n; i++)
+        {
+            // 3.1) s ← s * C
+            BelTMath.GfBlock.Multiply(currentS, BelTMath.C);
+
+            int offset = i * BlockSize;
+            EncryptBlock(x.Slice(offset, BlockSize),k,currentS,y.Slice(offset, BlockSize));
+        }
+
+        // Шаг 4: Возвратить Y (уже находится в буфере y благодаря слайсам)
+        CryptographicOperations.ZeroMemory(currentS);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EncryptBlock(
+    ReadOnlySpan<byte> input,
+    ReadOnlySpan<byte> k,
+    ReadOnlySpan<byte> s,
+    Span<byte> output)
+    {
+        // Используем твой BelTMath.GfBlock.Xor
+        Span<byte> buffer = stackalloc byte[BlockSize];
+        input.CopyTo(buffer);
+        BelTMath.GfBlock.Xor(buffer, s); // buffer = Xi ⊕ s
+
+        _block.Encrypt(buffer, k, output);
+
+        // Финальный XOR: Yi = Yi ⊕ s
+        BelTMath.GfBlock.Xor(output, s);
+    }
+}

--- a/BelTCrypto.Core/BelTSde.cs
+++ b/BelTCrypto.Core/BelTSde.cs
@@ -1,0 +1,22 @@
+﻿using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Core;
+
+internal class BelTSde : IBelTSde
+{
+    private readonly IBelTBlock _block;
+
+    public BelTSde(IBelTBlock block)
+    {
+        _block = block ?? throw new ArgumentNullException(nameof(block));
+    }
+    public void Decrypt(ReadOnlySpan<byte> y, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<byte> x)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Encrypt(ReadOnlySpan<byte> x, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<byte> y)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/BelTCrypto.Core/Factories/BelTDiskEncryptionFactory.cs
+++ b/BelTCrypto.Core/Factories/BelTDiskEncryptionFactory.cs
@@ -1,0 +1,28 @@
+﻿using BelTCrypto.Core.Interfaces;
+using System.Security.Cryptography;
+
+namespace BelTCrypto.Core.Factories;
+
+public static class BelTDiskEncryptionFactory
+{
+
+    public static IDiskEncryption Create(BeltDiskScheme scheme) => scheme switch
+    {
+        BeltDiskScheme.Bde => new BelTBde(BelTBlockFactory.Create()),
+        BeltDiskScheme.Sde => new BelTSde(BelTBlockFactory.Create()),
+        _ => throw new CryptographicException($"Режим {scheme} не поддерживается для BelT"),
+    };
+
+    public enum BeltDiskScheme
+    {
+        /// <summary>
+        /// Схема 1: belt-Bde
+        /// </summary>
+        Bde = 1,
+
+        /// <summary>
+        /// Схема 2: belt-Sde
+        /// </summary>
+        Sde = 2
+    }
+}

--- a/BelTCrypto.Core/Interfaces/IBelTBde.cs
+++ b/BelTCrypto.Core/Interfaces/IBelTBde.cs
@@ -1,0 +1,5 @@
+﻿namespace BelTCrypto.Core.Interfaces;
+
+public interface IBelTBde : IDiskEncryption
+{
+}

--- a/BelTCrypto.Core/Interfaces/IBelTSde.cs
+++ b/BelTCrypto.Core/Interfaces/IBelTSde.cs
@@ -1,0 +1,5 @@
+﻿namespace BelTCrypto.Core.Interfaces;
+
+public interface IBelTSde : IDiskEncryption
+{
+}

--- a/BelTCrypto.Core/Interfaces/IDiskEncryption.cs
+++ b/BelTCrypto.Core/Interfaces/IDiskEncryption.cs
@@ -1,0 +1,22 @@
+﻿namespace BelTCrypto.Core.Interfaces;
+
+public interface IDiskEncryption
+{
+    /// <summary>
+    /// Зашифрование данных (belt-bde или belt-sde)
+    /// </summary>
+    /// <param name="x">Исходные данные (содержимое сектора)</param>
+    /// <param name="k">Ключ (256 бит)</param>
+    /// <param name="s">Синхропосылка (128 бит, обычно номер сектора)</param>
+    /// <param name="y">Буфер для зашифрованных данных</param>
+    void Encrypt(ReadOnlySpan<byte> x, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<byte> y);
+
+    /// <summary>
+    /// Расшифрование данных (belt-bde-1 или belt-sde-1)
+    /// </summary>
+    /// <param name="y">Зашифрованные данные</param>
+    /// <param name="k">Ключ (256 бит)</param>
+    /// <param name="s">Синхропосылка (128 бит)</param>
+    /// <param name="x">Буфер для расшифрованных данных</param>
+    void Decrypt(ReadOnlySpan<byte> y, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<byte> x);
+}

--- a/BelTCrypto.Tests/BelTBdeTests.cs
+++ b/BelTCrypto.Tests/BelTBdeTests.cs
@@ -1,0 +1,70 @@
+﻿using BelTCrypto.Core.Factories;
+using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Tests;
+
+[TestFixture]
+internal class BelTBdeTests
+{
+    private IDiskEncryption _bde;
+
+    [SetUp]
+    public void Setup() => _bde = BelTDiskEncryptionFactory.Create(BelTDiskEncryptionFactory.BeltDiskScheme.Bde);
+
+    [Test]
+    public void Bde_TableA25_Encrypt()
+    {
+        // X = B194BAC8... (48 байт из таблицы H)
+        var x = Core.BelTMath.H[..48];
+
+        // K = E9DEE72C... (32 байта из таблицы H, смещение 128)
+        var k = Core.BelTMath.H[128..160];
+
+        // S = BE329713... (16 байт из таблицы H, смещение 192)
+        var s = Core.BelTMath.H[192..208];
+
+        var expectedY = new byte[]
+        {
+              0xE9, 0xCA, 0xB3, 0x2D, 0x87, 0x9C, 0xC5, 0x0C,
+              0x10, 0x37, 0x8E, 0xB0, 0x7C, 0x10, 0xF2, 0x63,
+              0x07, 0x25, 0x7E, 0x2D, 0xBE, 0x2B, 0x85, 0x4C, 
+              0xBC, 0x9F, 0x38, 0x28, 0x2D, 0x59, 0xD6, 0xA7,
+              0x7F, 0x95, 0x20, 0x01, 0xC5, 0xD1, 0x24, 0x4F,
+              0x53, 0x21, 0x0A, 0x27, 0xC2, 0x16, 0xD4, 0xBB
+        };
+
+        var actualY = new byte[x.Length];
+        _bde.Encrypt(x, k, s, actualY);
+
+        TestContext.Out.WriteLine($"Actual Y:   {BitConverter.ToString(actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {BitConverter.ToString(expectedY)}");
+
+        Assert.That(actualY, Is.EqualTo(expectedY), "BDE Encrypt Table A.25 failed");
+    }
+
+    [Test]
+    public void Bde_TableA25_Decrypt()
+    {
+        var y = Core.BelTMath.H[64..112];
+        var k = Core.BelTMath.H[160..192];
+        var s = Core.BelTMath.H[208..224];
+        var expectedX = new byte[] 
+        {
+             0x70, 0x41, 0xBC, 0x22, 0x63, 0x52, 0xC7, 0x06,
+             0xD0, 0x0E, 0xA8, 0xEF, 0x23, 0xCF, 0xE4, 0x6A,
+             0xFA, 0xE1, 0x18, 0x57, 0x7D, 0x03, 0x7F, 0xAC,
+             0xDC, 0x36, 0xE4, 0xEC, 0xC1, 0xF6, 0x57, 0x46,
+             0x09, 0xF2, 0x36, 0x94, 0x3F, 0xB8, 0x09, 0xE1,
+             0xBE, 0xE4, 0xA1, 0xC6, 0x86, 0xC1, 0x3A, 0xCC
+        };
+
+
+        var actualX = new byte[y.Length];
+        _bde.Decrypt(y, k, s, actualX);
+
+        TestContext.Out.WriteLine($"Actual X:   {BitConverter.ToString(actualX)}");
+        TestContext.Out.WriteLine($"Expected X: {BitConverter.ToString(expectedX.ToArray())}");
+
+        Assert.That(actualX, Is.EqualTo(expectedX.ToArray()), "BDE Decrypt Table A.25 failed");
+    }
+}


### PR DESCRIPTION
- Added BelTBde implementation of IBelTDiskEncryption
- Integrated GF(2^128) multiplication from BelTMath for mask evolution
- Implemented XEX (XOR-Encrypt-XOR) block processing logic
- Added NUnit tests based on Table A.25 (STB 34.101.31-2020)
- Optimized block processing with aggressive inlining and stackalloc

ref-on: Implement Block Disk Encryption (belt-bde)
https://github.com/PiterPoker/BelTCrypto.Net/issues/19