### PR TITLE
feat: implement belt-fmt decryption and refactor FMT logic

### DIFF
--- a/BelTCrypto.Core/BelTFmt.cs
+++ b/BelTCrypto.Core/BelTFmt.cs
@@ -1,0 +1,211 @@
+﻿using BelTCrypto.Core.Interfaces;
+using System.Buffers.Binary;
+using System.Numerics;
+using System.Security.Cryptography;
+
+namespace BelTCrypto.Core;
+
+internal class BelTFmt : IBelTFmt
+{
+    private readonly IBelTBlock _block;
+    private readonly IBelTWideBlock _wideBlock;
+
+    public BelTFmt(IBelTBlock block, IBelTWideBlock wideBlock)
+    {
+        _block = block ?? throw new ArgumentNullException(nameof(block));
+        _wideBlock = wideBlock ?? throw new ArgumentNullException(nameof(wideBlock));
+    }
+    public void Decrypt(ReadOnlySpan<ushort> y, int m, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<ushort> x)
+    {
+        // 1. Подготовка (как в твоем Encrypt)
+        int n = y.Length;
+        int n1 = (n + 1) / 2;
+        int n2 = n / 2;
+
+        int b1 = (int)Math.Ceiling(n1 * Math.Log2(m) / 64.0) * 64;
+        int b2 = (int)Math.Ceiling(n2 * Math.Log2(m) / 64.0) * 64;
+
+        // ТВОЯ подготовка S (прямо из твоего метода Encrypt)
+        Span<uint> sExt = stackalloc uint[6];
+        uint fmtInfo = (uint)(m & 0xFFFF) | ((uint)(n & 0xFFFF) << 16);
+        sExt[0] = fmtInfo;
+        sExt[5] = fmtInfo;
+        for (int i = 0; i < 4; i++)
+        {
+            sExt[i + 1] = BinaryPrimitives.ReadUInt32LittleEndian(s.Slice(i * 4, 4));
+        }
+
+        // ТВОИ константы C
+        var c = BelTMath.H24();
+
+        // Шаг 1: r ← Y
+        Span<ushort> r1 = stackalloc ushort[n1];
+        Span<ushort> r2 = stackalloc ushort[n2];
+        y[..n1].CopyTo(r1);
+        y[n1..].CopyTo(r2);
+
+        // Шаг 2: Итерации i=3, 2, 1 (Расшифрование — зеркально)
+        for (int i = 3; i >= 1; i--)
+        {
+            // ВНИМАНИЕ: Сначала правим r2, используя r1 (индексы 2i-1)
+            ApplyFeistelStepInverse(r1, r2, m, b1, n2, c[2 * i - 1], sExt[2 * i - 1], k);
+
+            // Затем правим r1, используя r2 (индексы 2i-2)
+            ApplyFeistelStepInverse(r2, r1, m, b2, n1, c[2 * i - 2], sExt[2 * i - 2], k);
+        }
+
+        // Шаг 3-4: Склеиваем и возвращаем
+        r1.CopyTo(x[..n1]);
+        r2.CopyTo(x[n1..]);
+    }
+
+    private void ApplyFeistelStepInverse(ReadOnlySpan<ushort> passive, Span<ushort> active, int m, int bj, int nj, uint ci, uint si, ReadOnlySpan<byte> k)
+    {
+        int dataBytes = bj / 8;
+        Span<byte> t = stackalloc byte[dataBytes + 8];
+
+        // 1. str2bin (ТВОЙ BlockUtils)
+        BlockUtils.Str2Bin(passive, m, t[..dataBytes]);
+
+        // 2. Записываем константы (Как в твоем коде)
+        BinaryPrimitives.WriteUInt32LittleEndian(t.Slice(dataBytes, 4), ci);
+        BinaryPrimitives.WriteUInt32LittleEndian(t.Slice(dataBytes + 4, 4), si);
+
+        // 3. RoundF (ТВОЙ метод)
+        RoundF(t, k);
+
+        // 4. bin2str (ТВОЙ BlockUtils)
+        Span<ushort> offset = stackalloc ushort[nj];
+        BlockUtils.Bin2Str(t, m, nj, offset);
+
+        // 5. Вычитание по модулю m (Операция ⊖ из стандарта)
+        for (int j = 0; j < nj; j++)
+        {
+            int diff = active[j] - (offset[j] % m);
+            if (diff < 0) diff += m;
+            active[j] = (ushort)(diff % m);
+        }
+    }
+
+    public void Encrypt(ReadOnlySpan<ushort> x, int m, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<ushort> y)
+    {
+        int n = x.Length;
+        int n1 = (n + 1) / 2;
+        int n2 = n / 2;
+
+        int b1 = (int)Math.Ceiling(n1 * Math.Log2(m) / 64.0) * 64;
+        int b2 = (int)Math.Ceiling(n2 * Math.Log2(m) / 64.0) * 64;
+
+        // --- ИСПРАВЛЕНИЕ №2 и №3 (Подготовка S и C) ---
+        Span<uint> sExt = stackalloc uint[6];
+
+        // S0 = <m>_16 || <n>_16. В памяти это [m_low, m_high, n_low, n_high]
+        // Чтобы BinaryPrimitives.WriteUInt32LittleEndian сработал верно, собираем uint так:
+        uint fmtInfo = (uint)(m & 0xFFFF) | ((uint)(n & 0xFFFF) << 16);
+        sExt[0] = fmtInfo;
+        sExt[5] = fmtInfo;
+
+        for (int i = 0; i < 4; i++)
+        {
+            // Читаем S1..S4 как LittleEndian, чтобы порядок байт в блоке t соответствовал СТБ
+            sExt[i + 1] = BinaryPrimitives.ReadUInt32LittleEndian(s.Slice(i * 4, 4));
+        }
+
+        // Константы C должны быть считаны как LittleEndian из таблицы H
+        // Если BelTMath.C6() внутри использует BigEndian - это сломает всё.
+        // Правильно: BinaryPrimitives.ReadUInt32LittleEndian(H.AsSpan(0, 4)) -> 0xC8BA94B1
+        var c = BelTMath.H24();
+
+        Span<ushort> r1 = stackalloc ushort[n1];
+        Span<ushort> r2 = stackalloc ushort[n2];
+        x[..n1].CopyTo(r1);
+        x[n1..].CopyTo(r2);
+
+        for (int i = 1; i <= 3; i++)
+        {
+            ApplyFeistelStep(r2, r1, m, b2, n1, c[2 * i - 2], sExt[2 * i - 2], k);
+            ApplyFeistelStep(r1, r2, m, b1, n2, c[2 * i - 1], sExt[2 * i - 1], k);
+        }
+
+        r1.CopyTo(y[..n1]);
+        r2.CopyTo(y[n1..]);
+    }
+
+    private void ApplyFeistelStep(ReadOnlySpan<ushort> passive, Span<ushort> active, int m, int bj, int nj, uint ci, uint si, ReadOnlySpan<byte> k)
+    {
+        // bj - это 64. Значит bj/8 = 8 байт данных.
+        // Общий размер t = 8 + 4 (Ci) + 4 (Si) = 16 байт.
+        int dataBytes = bj / 8;
+        Span<byte> t = stackalloc byte[dataBytes + 8];
+
+        // 1. str2bin (Заполняем t[0..7])
+        BlockUtils.Str2Bin(passive, m, t[..dataBytes]);
+
+        // 2. Записываем константы (Заполняем t[8..11] и t[12..15])
+        BinaryPrimitives.WriteUInt32LittleEndian(t.Slice(dataBytes, 4), ci);
+        BinaryPrimitives.WriteUInt32LittleEndian(t.Slice(dataBytes + 4, 4), si);
+
+        // 3. RoundF (Шифруем ВЕСЬ блок 16 байт)
+        RoundF(t, k);
+
+        // Передаем в bin2str ВЕСЬ зашифрованный блок t (16 байт), а не t[..8]!
+        Span<ushort> offset = stackalloc ushort[nj];
+        BlockUtils.Bin2Str(t, m, nj, offset);
+
+        for (int j = 0; j < nj; j++)
+        {
+            active[j] = (ushort)((active[j] + offset[j]) % m);
+        }
+    }
+
+    private void Belt32Block(Span<byte> t, ReadOnlySpan<byte> k)
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        Span<byte> t1Old = stackalloc byte[8]; // Вынесли из цикла
+
+        for (int i = 1; i <= 3; i++)
+        {
+            // 1) Копируем t[8..23] в буфер для шифрования
+            t.Slice(8, 16).CopyTo(buffer);
+            _block.Encrypt(buffer, k, buffer);
+
+            // XOR младших 8 байт с i
+            ulong low = BinaryPrimitives.ReadUInt64LittleEndian(buffer[..8]);
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer[..8], low ^ (ulong)i);
+
+            // 2) Сохраняем старый t1 (0..7)
+            t[..8].CopyTo(t1Old);
+
+            // 3) Обновляем t: t1 и t2 становятся результатом шифрования
+            buffer.CopyTo(t[..16]);
+
+            // 4) Новое t3 вычисляется как XOR старого t1 и нового t1
+            for (int j = 0; j < 8; j++)
+                t[16 + j] = (byte)(t1Old[j] ^ t[j]);
+
+            // (Опционально) Очистка временного буфера для безопасности
+            t1Old.Clear();
+        }
+    }
+
+    private void RoundF(Span<byte> t, ReadOnlySpan<byte> k)
+    {
+        int bitLength = t.Length * 8;
+
+        switch (bitLength)
+        {
+            case 128:
+                _block.Encrypt(t, k, t);
+                break;
+            case 192:
+                Belt32Block(t, k);
+                break;
+            default:
+                if (bitLength >= 256)
+                    _wideBlock.Encrypt(t, k, t);
+                else
+                    throw new CryptographicException("Неверная длина блока для roundf");
+                break;
+        }
+    }
+}

--- a/BelTCrypto.Core/BelTMath.cs
+++ b/BelTCrypto.Core/BelTMath.cs
@@ -175,6 +175,21 @@ public static class BelTMath
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
 
+    public static uint[] H24()
+    {
+        var c = H.AsSpan()[..24];
+
+        return
+    [
+        BinaryPrimitives.ReadUInt32LittleEndian(c[..4]),
+        BinaryPrimitives.ReadUInt32LittleEndian(c[4..8]),
+        BinaryPrimitives.ReadUInt32LittleEndian(c[8..12]),
+        BinaryPrimitives.ReadUInt32LittleEndian(c[12..16]),
+        BinaryPrimitives.ReadUInt32LittleEndian(c[16..20]),
+        BinaryPrimitives.ReadUInt32LittleEndian(c[20..24])
+    ];
+    }
+
     public static readonly byte[] H =
     [
         0xB1, 0x94, 0xBA, 0xC8, 0x0A, 0x08, 0xF5, 0x3B, 0x36, 0x6D, 0x00, 0x8E, 0x58, 0x4A, 0x5D, 0xE4,

--- a/BelTCrypto.Core/BlockUtils.cs
+++ b/BelTCrypto.Core/BlockUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("BelTCrypto.Tests")]
@@ -25,5 +26,38 @@ internal static class BlockUtils
         BinaryPrimitives.WriteUInt32LittleEndian(y[4..8], b);
         BinaryPrimitives.WriteUInt32LittleEndian(y[8..12], c);
         BinaryPrimitives.WriteUInt32LittleEndian(y[12..16], d);
+    }
+
+    internal static void Str2Bin(ReadOnlySpan<ushort> u, int m, Span<byte> output)
+    {
+        BigInteger value = 0;
+        BigInteger mBI = m;
+        BigInteger power = 1;
+
+        // u[0] - младший символ, вес m^0
+        for (int i = 0; i < u.Length; i++)
+        {
+            value += (BigInteger)u[i] * power;
+            power *= mBI;
+        }
+
+        output.Clear();
+        // Пишем как Little-Endian. Это заполнит output[0], output[1]... 
+        // Если число меньше bj, остаток буфера останется нулями (правильный padding).
+        value.TryWriteBytes(output, out _, isUnsigned: true, isBigEndian: false);
+    }
+
+    internal static void Bin2Str(ReadOnlySpan<byte> t, int m, int nj, Span<ushort> output)
+    {
+        // Читаем как Little-Endian.
+        BigInteger value = new(t, isUnsigned: true, isBigEndian: false);
+        BigInteger mBI = m;
+
+        for (int i = 0; i < nj; i++)
+        {
+            // Первый остаток - это всегда коэффициент при m^0 (т.е. первый символ)
+            value = BigInteger.DivRem(value, mBI, out BigInteger remainder);
+            output[i] = (ushort)remainder;
+        }
     }
 }

--- a/BelTCrypto.Core/Factories/BeltFmtFactory.cs
+++ b/BelTCrypto.Core/Factories/BeltFmtFactory.cs
@@ -1,0 +1,8 @@
+﻿using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Core.Factories;
+
+public static class BeltFmtFactory
+{
+    public static IBelTFmt Create() => new BelTFmt(BelTBlockFactory.Create(), BelTBlockFactory.CreateWide());
+}

--- a/BelTCrypto.Core/Interfaces/IBelTFmt.cs
+++ b/BelTCrypto.Core/Interfaces/IBelTFmt.cs
@@ -1,0 +1,16 @@
+﻿namespace BelTCrypto.Core.Interfaces;
+
+public interface IBelTFmt
+{
+    /// <summary>
+    /// Шифрование с сохранением формата (belt-fmt)
+    /// </summary>
+    /// <param name="x">Входное слово в алфавите Zm</param>
+    /// <param name="m">Размер алфавита (2..65536)</param>
+    /// <param name="k">Ключ 256 бит</param>
+    /// <param name="s">Синхропосылка 128 бит</param>
+    /// <param name="y">Выходное зашифрованное слово</param>
+    void Encrypt(ReadOnlySpan<ushort> x, int m, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<ushort> y);
+
+    void Decrypt(ReadOnlySpan<ushort> y, int m, ReadOnlySpan<byte> k, ReadOnlySpan<byte> s, Span<ushort> x);
+}

--- a/BelTCrypto.Tests/BelTFmtTests.cs
+++ b/BelTCrypto.Tests/BelTFmtTests.cs
@@ -1,0 +1,194 @@
+﻿using BelTCrypto.Core;
+using BelTCrypto.Core.Factories;
+using BelTCrypto.Core.Interfaces;
+
+namespace BelTCrypto.Tests;
+
+[TestFixture]
+public class BelTFmtTests
+{
+    private IBelTFmt _fmt;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fmt = BeltFmtFactory.Create();
+    }
+
+    [Test]
+    public void Encipher_TableA26_ShouldGenerateCorrectY10x10()
+    {
+        // --- 1. Исходные данные из таблицы А.26 ---
+        byte[] k = Core.BelTMath.H[128..160];
+        byte[] s = Core.BelTMath.H[192..208];
+
+        TestContext.Out.WriteLine($"k:   {BitConverter.ToString(k)}");
+        TestContext.Out.WriteLine($"s: {BitConverter.ToString(s)}");
+        int m = 10;
+        ushort[] x = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        // --- 2. Ожидаемый результат Y ---
+        ushort[] expectedY = { 6, 9, 3, 4, 7, 7, 0, 3, 5, 2 };
+
+        // Буфер для результата
+        ushort[] actualY = new ushort[x.Length];
+
+        // --- 3. Выполнение зашифрования ---
+        _fmt.Encrypt(x, m, k, s, actualY);
+
+        // Логирование для отладки
+        TestContext.Out.WriteLine($"Input X:    {string.Join(",", x)}");
+        TestContext.Out.WriteLine($"Actual Y:   {string.Join(",", actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {string.Join(",", expectedY)}");
+
+        // --- 4. Проверка ---
+        Assert.That(actualY, Is.EqualTo(expectedY), "Зашифрованное слово Y не совпадает с эталоном А.26");
+    }
+
+    [Test]
+    public void Encipher_TableA26_ShouldGenerateCorrectY58x21()
+    {
+        // --- 1. Исходные данные из таблицы А.26 ---
+        byte[] k = Core.BelTMath.H[128..160];
+        byte[] s = Core.BelTMath.H[192..208];
+
+        TestContext.Out.WriteLine($"k:   {BitConverter.ToString(k)}");
+        TestContext.Out.WriteLine($"s: {BitConverter.ToString(s)}");
+        int m = 58;
+        ushort[] x = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+
+        // --- 2. Ожидаемый результат Y ---
+        ushort[] expectedY = { 7, 4, 6, 21, 49, 55, 24, 23, 22, 50, 27, 39, 24, 24, 17, 32, 57, 43, 26, 5, 29 };
+
+        // Буфер для результата
+        ushort[] actualY = new ushort[x.Length];
+
+        // --- 3. Выполнение зашифрования ---
+        _fmt.Encrypt(x, m, k, s, actualY);
+
+        // Логирование для отладки
+        TestContext.Out.WriteLine($"Input X:    {string.Join(",", x)}");
+        TestContext.Out.WriteLine($"Actual Y:   {string.Join(",", actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {string.Join(",", expectedY)}");
+
+        // --- 4. Проверка ---
+        Assert.That(actualY, Is.EqualTo(expectedY), "Зашифрованное слово Y не совпадает с эталоном А.26");
+    }
+
+    [Test]
+    public void Encipher_TableA26_ShouldGenerateCorrectY65536x17()
+    {
+        // --- 1. Исходные данные из таблицы А.26 ---
+        byte[] k = Core.BelTMath.H[128..160];
+        byte[] s = Core.BelTMath.H[192..208];
+
+        TestContext.Out.WriteLine($"k:   {BitConverter.ToString(k)}");
+        TestContext.Out.WriteLine($"s: {BitConverter.ToString(s)}");
+        int m = 65536;
+        ushort[] x = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+
+        // --- 2. Ожидаемый результат Y ---
+        ushort[] expectedY = { 14290,31359,58054,51842,44653,34762,28652,48929,6541,13788,7784,46182,61098,43056,3564,21568,63878 };
+
+        // Буфер для результата
+        ushort[] actualY = new ushort[x.Length];
+
+        // --- 3. Выполнение зашифрования ---
+        _fmt.Encrypt(x, m, k, s, actualY);
+
+        // Логирование для отладки
+        TestContext.Out.WriteLine($"Input X:    {string.Join(",", x)}");
+        TestContext.Out.WriteLine($"Actual Y:   {string.Join(",", actualY)}");
+        TestContext.Out.WriteLine($"Expected Y: {string.Join(",", expectedY)}");
+
+        // --- 4. Проверка ---
+        Assert.That(actualY, Is.EqualTo(expectedY), "Зашифрованное слово Y не совпадает с эталоном А.26");
+    }
+
+    [Test]
+    public void Decipher_TableA26_ShouldGenerateCorrectX10x10()
+    {
+        // --- 1. Исходные данные из таблицы А.26 ---
+        // Те же ключи и параметры, что и в тесте на зашифрование
+        byte[] k = Core.BelTMath.H[128..160];
+        byte[] s = Core.BelTMath.H[192..208];
+        int m = 10;
+
+        // Входное слово для расшифрования — это результат (Y) из таблицы А.26
+        ushort[] y = { 6, 9, 3, 4, 7, 7, 0, 3, 5, 2 };
+
+        // Ожидаемый результат — исходное слово X
+        ushort[] expectedX = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        // Буфер для результата расшифрования
+        ushort[] actualX = new ushort[y.Length];
+
+        // --- 2. Выполнение расшифрования ---
+        _fmt.Decrypt(y, m, k, s, actualX);
+
+        // Логирование
+        TestContext.Out.WriteLine($"Input Y:    {string.Join(",", y)}");
+        TestContext.Out.WriteLine($"Actual X:   {string.Join(",", actualX)}");
+        TestContext.Out.WriteLine($"Expected X: {string.Join(",", expectedX)}");
+
+        // --- 3. Проверка ---
+        Assert.That(actualX, Is.EqualTo(expectedX), "Расшифрованное слово X не совпадает с эталоном А.26");
+    }
+    [Test]
+    public void Decipher_TableA26_ShouldGenerateCorrectX58x21()
+    {
+        // --- 1. Исходные данные из таблицы А.26 ---
+        byte[] k = Core.BelTMath.H[128..160];
+        byte[] s = Core.BelTMath.H[192..208];
+        int m = 58;
+
+        // Входное слово Y из таблицы А.26
+        ushort[] y = { 7, 4, 6, 21, 49, 55, 24, 23, 22, 50, 27, 39, 24, 24, 17, 32, 57, 43, 26, 5, 29 };
+
+        // Ожидаемый результат X
+        ushort[] expectedX = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+
+        // Буфер для результата
+        ushort[] actualX = new ushort[y.Length];
+
+        // --- 2. Выполнение расшифрования ---
+        _fmt.Decrypt(y, m, k, s, actualX);
+
+        // Логирование
+        TestContext.Out.WriteLine($"Input Y:    {string.Join(",", y)}");
+        TestContext.Out.WriteLine($"Actual X:   {string.Join(",", actualX)}");
+        TestContext.Out.WriteLine($"Expected X: {string.Join(",", expectedX)}");
+
+        // --- 3. Проверка ---
+        Assert.That(actualX, Is.EqualTo(expectedX), "Расшифрованное слово X (58x21) не совпадает с эталоном А.26");
+    }
+
+    [Test]
+    public void Decipher_TableA26_ShouldGenerateCorrectX65536x17()
+    {
+        // --- 1. Исходные данные из таблицы А.26 ---
+        byte[] k = Core.BelTMath.H[128..160];
+        byte[] s = Core.BelTMath.H[192..208];
+        int m = 65536;
+
+        // Входное слово Y из таблицы А.26
+        ushort[] y = { 14290, 31359, 58054, 51842, 44653, 34762, 28652, 48929, 6541, 13788, 7784, 46182, 61098, 43056, 3564, 21568, 63878 };
+
+        // Ожидаемый результат X
+        ushort[] expectedX = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+
+        // Буфер для результата
+        ushort[] actualX = new ushort[y.Length];
+
+        // --- 2. Выполнение расшифрования ---
+        _fmt.Decrypt(y, m, k, s, actualX);
+
+        // Логирование
+        TestContext.Out.WriteLine($"Input Y:    {string.Join(",", y)}");
+        TestContext.Out.WriteLine($"Actual X:   {string.Join(",", actualX)}");
+        TestContext.Out.WriteLine($"Expected X: {string.Join(",", expectedX)}");
+
+        // --- 3. Проверка ---
+        Assert.That(actualX, Is.EqualTo(expectedX), "Расшифрованное слово X (65536x17) не совпадает с эталоном А.26");
+    }
+}


### PR DESCRIPTION
- Implement `Decrypt` method according to STB 34.101.31-2020 (clause 7.10.6).
- Refactor `BelTFmt` to separate math primitives into `BlockUtils`.
- Fix modulo subtraction logic to correctly handle character ranges.
- Improve memory efficiency using Span and stackalloc for round buffers.
- Add comprehensive NUnit tests based on Table A.26 (m=10, m=58, m=65536).

Compliance: STB 34.101.31-2020 clause 7.10
ref-on: Implement Format-Preserving Encryption (belt-fmt) per STB 34.101.31 #23